### PR TITLE
Only run workflow on pull request to main. Closes #13

### DIFF
--- a/.github/workflows/deno-ci-check-build.yaml
+++ b/.github/workflows/deno-ci-check-build.yaml
@@ -1,16 +1,13 @@
 name: "Deno CI - Check and Build"
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     branches:
-      - "**"
+      - main
 
 jobs:
   build:
-    name: Check and Build
+    name: Check and Build # This name is used in gihub rules
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Change the *Deno CI - Check and Build* workflow to only run on pull requests to main instead of push and pull request to any branch.